### PR TITLE
Extend YARP_DATA_DIRS to load model through RF

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -123,7 +123,7 @@ RUN git clone https://github.com/robotology/icub-models.git --depth 1 --branch $
 # Set environmental variables
 ENV DISPLAY=:1
 ENV ICUBcontrib_DIR=/workspace/iCubContrib
-ENV YARP_DATA_DIRS=/usr/local/share/yarp:/usr/local/share/iCub:${ICUBcontrib_DIR}/share/ICUBcontrib
+ENV YARP_DATA_DIRS=/usr/local/share/yarp:/usr/local/share/iCub:${ICUBcontrib_DIR}/share/ICUBcontrib:${ICUBcontrib_DIR}/share/gazebo
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/yarp:/usr/local/lib/robottestingframework:${ICUBcontrib_DIR}/lib
 
 # Create user gitpod


### PR DESCRIPTION
With this change, `yarp resource --from models/object/mesh.stl` works just fine!

This means that we can use RF to retrieve the model w/o replicating files unnecessarily.

cc @vvasco