### PR TITLE
Fix comm to/from depthCamera

### DIFF
--- a/app/scripts/assignment_web-contest-sandbox-icub.xml
+++ b/app/scripts/assignment_web-contest-sandbox-icub.xml
@@ -19,15 +19,9 @@
   </module>
 
   <connection>
-      <from>/icubSim/camcalib/left/out</from>
+      <from>/depthCamera/rgbImage:o</from>
       <to>/img:i</to>
       <protocol>unix_stream</protocol>
-  </connection>
-
-  <connection>
-      <from>/cam:rpc</from>
-      <to>/depthCamera/rpc:i</to>
-      <protocol>tcp</protocol>
   </connection>
 
   <connection>


### PR DESCRIPTION
This PR allows for fixing the following issues:
- receiving depth inputs from the camera;
- connecting first to depth camera ahead of asking fov.

cc @vvasco 